### PR TITLE
Update AttributeExpansion.java

### DIFF
--- a/src/main/java/at/helpch/placeholderapi/expansion/attribute/AttributeExpansion.java
+++ b/src/main/java/at/helpch/placeholderapi/expansion/attribute/AttributeExpansion.java
@@ -25,7 +25,7 @@ public class AttributeExpansion extends PlaceholderExpansion implements VersionS
 
     public AttributeExpansion() {
         for (final Attribute attribute : Attribute.values()) {
-            if (!attribute.name().startsWith("GENERIC_")) {
+            if (!attribute.name().startsWith("GENERIC_") && !attribute.name().startsWith("PLAYER_")) {
                 continue;
             }
 


### PR DESCRIPTION
Update for not limiting the new 1.20.6 and 1.21 attributes, which some of them doesn't start with 'GENERIC_'