### PR TITLE
fix for 1.21.3+ IncompatibleClassChangeError

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,11 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT'
-    compileOnly 'me.clip:placeholderapi:2.11.1'
+    compileOnly 'org.spigotmc:spigot-api:1.21.4-R0.1-SNAPSHOT'
+    compileOnly 'me.clip:placeholderapi:2.11.6'
     compileOnly 'org.jetbrains:annotations:22.0.0'
 }
 
 shadowJar {
-    archiveName("Expansion-Attribute-${project.version}.jar")
+    archiveFileName = "Expansion-Attribute-${project.version}.jar"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/at/helpch/placeholderapi/expansion/attribute/AttributeExpansion.java
+++ b/src/main/java/at/helpch/placeholderapi/expansion/attribute/AttributeExpansion.java
@@ -1,5 +1,6 @@
 package at.helpch.placeholderapi.expansion.attribute;
 
+import at.helpch.placeholderapi.expansion.attribute.util.AttributeUtil;
 import at.helpch.placeholderapi.expansion.attribute.util.ServerVersion;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
@@ -24,16 +25,17 @@ public class AttributeExpansion extends PlaceholderExpansion implements VersionS
     private final List<String> placeholders = new ArrayList<>();
 
     public AttributeExpansion() {
-        for (final Attribute attribute : Attribute.values()) {
-            if (!attribute.name().startsWith("GENERIC_") && !attribute.name().startsWith("PLAYER_")) {
+        for (final Attribute attribute : AttributeUtil.getAttributes()) {
+            if (ServerVersion.HAS_KEYS) {
+                attributes.put(AttributeUtil.getKey(attribute).getKey(), attribute);
+            }
+
+            if (!AttributeUtil.getName(attribute).startsWith("GENERIC_") && !AttributeUtil.getName(attribute).startsWith("PLAYER_")) {
                 continue;
             }
 
-            attributes.put(attribute.name(), attribute);
+            attributes.put(AttributeUtil.getName(attribute), attribute);
 
-            if (ServerVersion.HAS_KEYS) {
-                attributes.put(attribute.getKey().getKey(), attribute);
-            }
         }
 
         placeholders.add("%attribute_player_has_<attribute>%");

--- a/src/main/java/at/helpch/placeholderapi/expansion/attribute/AttributeExpansion.java
+++ b/src/main/java/at/helpch/placeholderapi/expansion/attribute/AttributeExpansion.java
@@ -30,10 +30,6 @@ public class AttributeExpansion extends PlaceholderExpansion implements VersionS
                 attributes.put(AttributeUtil.getKey(attribute).getKey(), attribute);
             }
 
-            if (!AttributeUtil.getName(attribute).startsWith("GENERIC_") && !AttributeUtil.getName(attribute).startsWith("PLAYER_")) {
-                continue;
-            }
-
             attributes.put(AttributeUtil.getName(attribute), attribute);
 
         }

--- a/src/main/java/at/helpch/placeholderapi/expansion/attribute/util/AttributeUtil.java
+++ b/src/main/java/at/helpch/placeholderapi/expansion/attribute/util/AttributeUtil.java
@@ -1,0 +1,58 @@
+package at.helpch.placeholderapi.expansion.attribute.util;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public final class AttributeUtil {
+
+    private static Method valuesMethod = null;
+    private static Method keyMethod = null;
+    private static Method nameMethod = null;
+
+    static {
+        try {
+            valuesMethod = Class.forName("org.bukkit.attribute.Attribute").getMethod("values");
+            keyMethod = Class.forName("org.bukkit.attribute.Attribute").getMethod("getKey");
+            nameMethod = Class.forName("org.bukkit.attribute.Attribute").getMethod("name");
+        } catch (NoSuchMethodException | ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private AttributeUtil() {}
+
+    /*
+    Use reflection as since 1.21, Attribute class has changed to an Interface causing IncompatibleClassChangeError
+    This allows backwards compatibility
+     */
+    public static Attribute[] getAttributes() {
+        if (valuesMethod == null) {
+            return new Attribute[]{};
+        }
+        try {
+            return (Attribute[]) valuesMethod.invoke(null);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return Attribute.values();
+    }
+
+    public static NamespacedKey getKey(final Attribute attribute) {
+        try {
+            return (NamespacedKey) keyMethod.invoke(attribute);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            return null;
+        }
+    }
+
+    public static String getName(final Attribute attribute) {
+        try {
+            return (String) nameMethod.invoke(attribute);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Closes #3 

Uses reflection to still allow backwards compatibility